### PR TITLE
Fix typo

### DIFF
--- a/config/larapay.php
+++ b/config/larapay.php
@@ -110,7 +110,7 @@ return [
         'server'       => env('ZARINPAL_SERVER', 'germany'),
         'email'        => env('ZARINPAL_EMAIL', ''),
         'mobile'       => env('ZARINPAL_MOBILE', '09xxxxxxxxx'),
-        'description'  => env('ZARINPAL_MOBILE', 'powered-by-Larapay'),
+        'description'  => env('ZARINPAL_DESCRIPTION', 'powered-by-Larapay'),
     ],
 
     /*


### PR DESCRIPTION
The mobile `env` config in duplicated instead of `description` by mistake.